### PR TITLE
remove esp8266 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,5 @@
-CircuitPython Kernel
+CircuitPython Jupyter Kernel
 ====================
-
-.. image:: https://cdn-learn.adafruit.com/guides/images/000/002/051/medium310/Untitled-3.png?1528919538
-
 
 .. image:: https://readthedocs.org/projects/circuitpython-kernel/badge/?version=latest
     :target: https://circuitpython-kernel.readthedocs.io/en/latest/?badge=latest
@@ -19,15 +16,14 @@ CircuitPython Kernel
     :alt: Build Status
 
 
-The CircuitPython Kernel is a `Jupyter Kernel <https://jupyter.org/>`_ designed to interact with Adafruit boards
+The CircuitPython Jupyter Kernel is a `Jupyter Kernel <https://jupyter.org/>`_ designed to interact with Adafruit boards
 running `CircuitPython <https://github.com/adafruit/circuitpython>`_ from within a Jupyter Notebook.
 
 
 Status
 ------
 
-This project's status is experimental. It has been tested with CircuitPython (SAMD) boards and the
-Feather HUZZAH (ESP8266) with CircuitPython 3.x.
+This project's status is experimental and is compatible with CircuitPython SA
 
 It may break, and if it does, please file an
 `issue on this repository <https://circuitpython-kernel.readthedocs.io/en/latest/contributing.html>`__.
@@ -50,17 +46,11 @@ Designed for CircuitPython (SAMD21 and SAMD51)
 -  `Adafruit ItsyBitsy M4 Express <https://www.adafruit.com/product/3800>`__
 
 
-Other Adafruit Boards
-~~~~~~~~~~~~~~~~~~~~~
-
--  `Adafruit Feather HUZZAH ESP8266 <https://www.adafruit.com/products/2821>`__
-
-
 Download
 --------
 
 Official .zip files are available through the
-`latest GitHub releases <https://github.com/adafruit/circuitpython_kernel/releases>`__.
+`latest GitHub releases <https://github.com/adafruit/circuitpython_jupyter_kernel/releases>`__.
 
 
 Install
@@ -77,8 +67,8 @@ Optional::
 
 CircuitPython kernel::
 
-    cd circuitpython_kernel/
-    python3 setup.py install; python3 -m circuitpython_kernel.install
+    cd circuitpython_jupyter_kernel/
+    python3 setup.py install; python3 -m circuitpython_jupyter_kernel.install
 
 Then run with one of::
 

--- a/circuitpython_kernel/board.py
+++ b/circuitpython_kernel/board.py
@@ -9,9 +9,8 @@ from serial.serialutil import SerialException
 BOARD_LOGGER = logging.getLogger(__name__)
 
 
-# Vendor IDs
-ADAFRUIT_VID = 0x239A # SAMD
-ESP8266_VID = 0x10C4 # Huzzah ESP8266
+# Any Adafruit Board
+ADAFRUIT_VID = 0x239A
 
 # repl commands
 CHAR_CTRL_A = b'\x01'
@@ -144,7 +143,7 @@ class Board:
         for port in comports():
             # print out each device
             BOARD_LOGGER.debug(port.device)
-            if port.vid == ADAFRUIT_VID or port.vid == ESP8266_VID:
+            if port.vid == ADAFRUIT_VID:
                 BOARD_LOGGER.debug(f"CircuitPython Board Found at: {port.device}")
                 BOARD_LOGGER.debug(f"Connected? {self.connected}")
                 return port.device

--- a/docs/boardprep.md
+++ b/docs/boardprep.md
@@ -4,20 +4,7 @@
 Before you start using the CircuitPython_Kernel, you'll need a board running CircuitPython. If you're not sure if
 the board plugged into your computer is running CircuitPython, check your file explorer for a drive named `CIRCUITPY`
 
-## Designed for CircuitPython (SAMD21 and SAMD51)
-
-### Boards Supported:
-
- - [Circuit Playground Express](https://www.adafruit.com/product/3333)
- - [Feather M0](https://www.adafruit.com/product/3403)
- - [Trinket M0](https://www.adafruit.com/product/3500)
- - [Metro M0 Express](https://www.adafruit.com/product/3505)
- - [Gemma M0](https://www.adafruit.com/product/3501)
- - [ItsyBitsy M0](https://www.adafruit.com/product/3727)
-
- - [Metro M4 ]( https://www.adafruit.com/product/3382)
- - [ItsyBitsy M4](https://www.adafruit.com/product/3727)
-
+This kernel supports all Adafruit CircuitPython boards (SAMD21/SAMD51).
 
 ### Installing CircuitPython Firmware
 
@@ -25,21 +12,6 @@ the board plugged into your computer is running CircuitPython, check your file e
 - Plug in board and double click the **reset** button to enter bootloader mode.
 - Drag and drop the \*.uf2 CircuitPython file to the USB drive.
 - If you see the `CIRCUITPY` as the new name of the USB drive, you're ready to go.
-
-
-## Adafruit Feather Huzzah ESP8266
-
-While they do work with CircuitPython_Kernel, ESP8266-based boards require a different type of installation and configuration
-from the boards designed for circuitpython.
-
-### Installing CircuitPython Firmware
-
-- `python3 -m pip install esptool`
-- Download the [CircuitPython Firmware (.bin file) from the CircuitPython Repo](https://github.com/adafruit/circuitpython/releases)
-- Install the [SiLabs CP210x driver](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)
-- Erase flash `python3 esptool.py --port /path/to/ESP8266 erase_flash`
-- Load firmware: `esptool.py --port /path/to/ESP8266 --baud 460800 write_flash --flash_size=detect 0 firmware.bin`
-- Press reset or unplug/plug the board.
 
 ### Access the REPL
 

--- a/travis_pypi_setup.py
+++ b/travis_pypi_setup.py
@@ -21,7 +21,7 @@ except:
     from urllib.request import urlopen
 
 
-GITHUB_REPO = 'willingc/circuitpython_kernel'
+GITHUB_REPO = 'adafruit/circuitpython_jupyter_kernel'
 TRAVIS_CONFIG_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), '.travis.yml')
 


### PR DESCRIPTION
Removing support for ESP8266, reflecting CircuitPython 4.0.

Addressing https://github.com/adafruit/circuitpython_jupyter_kernel/issues/21